### PR TITLE
Fix promotion dismiss button position

### DIFF
--- a/components/section-promotion.js
+++ b/components/section-promotion.js
@@ -10,8 +10,8 @@ export function PromotionSection () {
   if (!isVisible) return null
 
   return (
-    <div className='max-w-[var(--max-width-total)] flex w-full p-2 text-primary-foreground bg-primary justify-between items-center'>
-      <div className='w-full relative'>
+    <div className='max-w-[var(--max-width-total)] flex w-full p-2 text-primary-foreground bg-primary justify-between items-center relative'>
+      <div className='w-full'>
         <div className='flex items-center justify-center gap-2 sm:gap-8'>
           <p className='text-sm font-medium'>
             Want a second opinion on the news that you&apos;re reading?
@@ -23,7 +23,7 @@ export function PromotionSection () {
       </div>
       <X
         onClick={() => setIsVisible(false)}
-        className='text-primary-foreground h-4 w-4 hover:cursor-pointer'
+        className='text-primary-foreground h-4 w-4 hover:cursor-pointer absolute top-2 right-2'
       />
       <span className='sr-only'>Dismiss</span>
     </div>


### PR DESCRIPTION
Move the dismiss (X) button to the top right of the black background in the promotion component.

* Adjust the CSS to position the dismiss (X) button correctly using `absolute`, `top-2`, and `right-2` classes.
* Update the structure of the promotion component to make the dismiss (X) button a child of the main container with `relative` positioning.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/csikosbalint/report/pull/2?shareId=ad492ab7-150d-40ec-b380-158306f1b16e).